### PR TITLE
Temporarily bypass newer webview callback

### DIFF
--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -166,6 +166,9 @@ public class TurbolinksSession implements TurbolinksScrollUpCallback {
                 onError(new TurbolinksError(errorCode, description));
             }
 
+            // Temporarily bypass this newer callback as it seems to be picking up on errors outside
+            // of the crm web app. We will add analytics to this method to try and learn what is
+            // causing it to get hit so often
 //            @Override
 //            @RequiresApi(Build.VERSION_CODES.M)
 //            public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -160,19 +160,22 @@ public class TurbolinksSession implements TurbolinksScrollUpCallback {
 
             @Override
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) { return; }
+//                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) { return; }
                 super.onReceivedError(view, errorCode, description, failingUrl);
                 TurbolinksLog.d("onReceivedError (<23): " + errorCode);
                 onError(new TurbolinksError(errorCode, description));
             }
 
-            @Override
-            @RequiresApi(Build.VERSION_CODES.M)
-            public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
-                super.onReceivedError(view, request, error);
-                TurbolinksLog.d("onReceivedError (>=23): " + error.getErrorCode());
-                onError(new TurbolinksError(error.getErrorCode(), error.getDescription().toString()));
-            }
+//            @Override
+//            @RequiresApi(Build.VERSION_CODES.M)
+//            public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+//                super.onReceivedError(view, request, error);
+//
+//                if (request.isForMainFrame()) {
+//                    TurbolinksLog.d("onReceivedError (>=23): " + error.getErrorCode());
+//                    onError(new TurbolinksError(error.getErrorCode(), error.getDescription().toString()));
+//                }
+//            }
 
             @Override
             @RequiresApi(Build.VERSION_CODES.M)


### PR DESCRIPTION
This is because the newer one appears to be picking up on many more errors than
the old one, causing issues for some users trying to use the app. This is perhaps because we weren't checking to see if the error occurred in the 'main frame' of the webview. It is possible that some users had processes in an outside frame erroring out and it was being picked up in this callback.