### PR TITLE
Update Kotlin lib version and remove unused Gradle settings

### DIFF
--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -1,19 +1,6 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
-
-buildscript {
-    ext.libVersionName = '1.0.9'
-
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-    }
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
 }
 
 android {
@@ -22,11 +9,14 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 11
-        versionName "$libVersionName"
+        versionName "1.0.9"
 
         // Define ProGuard rules for this android library project. These rules will be applied when
         // a consumer of this library sets 'minifyEnabled true'.
         consumerProguardFiles 'proguard-consumer-rules.pro'
+    }
+    buildFeatures {
+        viewBinding true
     }
     buildTypes {
         release {
@@ -51,94 +41,6 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:3.1.2'
     testImplementation 'org.mockito:mockito-core:1.10.19'
     testImplementation 'junit:junit:4.12'
-    implementation "androidx.core:core-ktx:+"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}
-
-ext {
-    bintrayRepo = 'maven'
-    bintrayName = 'turbolinks-android'
-
-    publishedGroupId = 'com.basecamp'
-    artifact = 'turbolinks'
-
-    libraryName = 'Turbolinks Android'
-    libraryDescription = 'Turbolinks for Android'
-    libraryVersion = "$libVersionName"
-
-    siteUrl = 'https://github.com/basecamp/turbolinks-android'
-    gitUrl = 'https://github.com/basecamp/turbolinks-android.git'
-
-    developerId = 'basecamp'
-    developerName = 'Basecamp'
-    developerEmail = 'support@basecamp.com'
-}
-
-// Maven
-group = publishedGroupId
-version = libraryVersion
-
-install {
-    repositories.mavenInstaller {
-        // This generates POM.xml with proper parameters
-        pom {
-            project {
-                packaging 'aar'
-                groupId publishedGroupId
-                artifactId artifact
-
-                // Add your description here
-                name libraryName
-                description libraryDescription
-
-                developers {
-                    developer {
-                        id developerId
-                        name developerName
-                        email developerEmail
-                    }
-                }
-            }
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-artifacts {
-    archives javadocJar
-    archives sourcesJar
-}
-
-// Bintray
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_API_KEY')
-
-    configurations = ['archives']
-    pkg {
-        repo = bintrayRepo
-        name = bintrayName
-        desc = libraryDescription
-        publish = true
-        publicDownloadNumbers = true
-        version {
-            desc = libraryDescription
-        }
-    }
-}
-repositories {
-    mavenCentral()
+    implementation "androidx.core:core-ktx:1.5.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }


### PR DESCRIPTION
This PR cleans up the Gradle file by removing all of the bintray config settings which are only used for building the project as a standalone library (which we do not do for Wealthbox). We also update the kotlin lib version and use the newer Gradle syntax for plugins.