### PR TITLE
Update target SDK to API 30

### DIFF
--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -4,10 +4,10 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 11
         versionName "1.0.9"
 

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -11,6 +11,7 @@ import android.os.Handler;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -156,9 +157,22 @@ public class TurbolinksView extends FrameLayout {
         if (webView.getParent() == refreshLayout) return false;
 
         refreshLayout.setEnabled(pullToRefreshEnabled);
+        removeWebViewFromParent(webView, screenshotsEnabled);
 
-        if (webView.getParent() instanceof TurbolinksSwipeRefreshLayout) {
-            TurbolinksSwipeRefreshLayout previousRefreshLayout = (TurbolinksSwipeRefreshLayout) webView.getParent();
+        // Set the webview background to match the container background
+        if (getBackground() instanceof ColorDrawable) {
+            webView.setBackgroundColor(((ColorDrawable) getBackground()).getColor());
+        }
+
+        webView.setVisibility(View.VISIBLE);
+        refreshLayout.addView(webView);
+        return true;
+    }
+
+    void removeWebViewFromParent(WebView webView, boolean screenshotsEnabled) {
+        ViewParent parent = webView.getParent();
+        if (parent instanceof TurbolinksSwipeRefreshLayout) {
+            TurbolinksSwipeRefreshLayout previousRefreshLayout = (TurbolinksSwipeRefreshLayout) parent;
             TurbolinksView previousTurbolinksView = (TurbolinksView) previousRefreshLayout.getParent();
 
             if (screenshotsEnabled) previousTurbolinksView.screenshotView();
@@ -173,16 +187,9 @@ public class TurbolinksView extends FrameLayout {
             } catch (Exception e) {
                 previousRefreshLayout.removeView(webView);
             }
+        } else if (parent != null && parent instanceof ViewGroup) {
+            ((ViewGroup) parent).removeView(webView);
         }
-
-        // Set the webview background to match the container background
-        if (getBackground() instanceof ColorDrawable) {
-            webView.setBackgroundColor(((ColorDrawable) getBackground()).getColor());
-        }
-
-        webView.setVisibility(View.VISIBLE);
-        refreshLayout.addView(webView);
-        return true;
     }
 
     /**


### PR DESCRIPTION
This PR updates the build SDK to Android 11 (API 30) to match the core app. It also addresses a somewhat rare crash where the webview is not removed from its parent (in our Wealthbox case this would be a flyout) before attempting to attach to a turbolinks view.