### PR TITLE
Remove debug logs from release build

### DIFF
--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -25,8 +25,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 }
 

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksLog.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksLog.java
@@ -41,6 +41,10 @@ class TurbolinksLog {
      * @param msg Message to log.
      */
     private static void log(int logLevel, String tag, String msg) {
+        if (!BuildConfig.DEBUG) {
+            return;
+        }
+        
         switch (logLevel) {
             case Log.DEBUG:
                 if (debugLoggingEnabled) {


### PR DESCRIPTION
We early return out of the TurbolinksLog logging function if the build config is not `DEBUG`. This ensures that logs cannot be seen using logcat on a release build of the app. This addresses a concern raised during our Leviathan pentest.

This PR also bumps the Java version from 8 to 11. I had made this change a while ago but never made a PR for it. The main app has been running on 11 and in the Play Store since August 18, 2021.