### PR TITLE
Use the core version number from the parent project

### DIFF
--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -41,6 +41,6 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:3.1.2'
     testImplementation 'org.mockito:mockito-core:1.10.19'
     testImplementation 'junit:junit:4.12'
-    implementation "androidx.core:core-ktx:1.5.0"
+    implementation "androidx.core:core-ktx:$core_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }


### PR DESCRIPTION
This ensures everything is built using the same kotlin core version