### PR TITLE
Add new adapter method to allow implementing app to override a request

### DIFF
--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksAdapter.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksAdapter.java
@@ -54,5 +54,5 @@ public interface TurbolinksAdapter {
 
     void sendAnalytics(String title, HashMap<String, String> params);
 
-    boolean shouldOverrideResponse(WebResourceRequest request);
+    boolean shouldOverrideRequest(WebResourceRequest request);
 }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksAdapter.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksAdapter.java
@@ -1,5 +1,7 @@
 package com.basecamp.turbolinks;
 
+import android.webkit.WebResourceRequest;
+
 import java.util.HashMap;
 
 /**
@@ -51,4 +53,6 @@ public interface TurbolinksAdapter {
     void visitProposedToLocationWithAction(String location, String action);
 
     void sendAnalytics(String title, HashMap<String, String> params);
+
+    boolean shouldOverrideResponse(WebResourceRequest request);
 }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -141,7 +141,7 @@ public class TurbolinksSession implements TurbolinksScrollUpCallback {
             public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
                 String newLocation = request.getUrl().toString();
                 TurbolinksLog.d("shouldOverrideUrlLoading " + view.getUrl() + " new: " + newLocation);
-                if (turbolinksAdapter.shouldOverrideResponse(request)) {
+                if (turbolinksAdapter.shouldOverrideRequest(request)) {
                   return true;
                 }
 

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -8,8 +8,6 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import androidx.annotation.RequiresApi;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -20,6 +18,8 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+
+import androidx.annotation.RequiresApi;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -141,6 +141,10 @@ public class TurbolinksSession implements TurbolinksScrollUpCallback {
             public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
                 String newLocation = request.getUrl().toString();
                 TurbolinksLog.d("shouldOverrideUrlLoading " + view.getUrl() + " new: " + newLocation);
+                if (turbolinksAdapter.shouldOverrideResponse(request)) {
+                  return true;
+                }
+
                 if (!turbolinksIsReady || coldBootInProgress || newLocation.equals(view.getUrl())) {
                     return false;
                 }


### PR DESCRIPTION
Adding this method to the adapter allows the implementing app (Wealthbox) an opportunity to override a cold boot request. In the current use case this is to intercept a redirect to an interstitial page in Wealthbox so that we can present the page content in a non-turbolinks interstitial specific fragment.