### PR TITLE
Add JDT file and fix build config deprecation

### DIFF
--- a/turbolinks/.settings/org.eclipse.jdt.core.prefs
+++ b/turbolinks/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.source=17

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -17,6 +17,7 @@ android {
   }
   buildFeatures {
     viewBinding true
+    buildConfig true
   }
   buildTypes {
     release {


### PR DESCRIPTION
A couple of small updates to work with the latest AGP and IDE of the [parent android repo](https://github.com/starburstlabs/crm-turbolinks-android/pull/81)